### PR TITLE
Make persist interval for remote state backend configurable

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -26,6 +28,22 @@ import (
 
 // test hook called between plan+apply during opApply
 var testHookStopPlanApply func()
+
+var (
+	defaultPersistInterval                 = 20
+	persistIntervalEnvironmentVariableName = "TF_BACKEND_PERSIST_INTERVAL_SECONDS"
+)
+
+func getEnvAsInt(envName string, defaultValue int) int {
+	if val, exists := os.LookupEnv(envName); exists {
+		parsedVal, err := strconv.Atoi(val)
+		if err == nil {
+			return parsedVal
+		}
+		log.Printf("[ERROR] Can't parse value '%s' of environment variable '%s'", val, envName)
+	}
+	return defaultValue
+}
 
 func (b *Local) opApply(
 	stopCtx context.Context,
@@ -84,7 +102,8 @@ func (b *Local) opApply(
 	// stateHook uses schemas for when it periodically persists state to the
 	// persistent storage backend.
 	stateHook.Schemas = schemas
-	stateHook.PersistInterval = 20 * time.Second // arbitrary interval that's hopefully a sweet spot
+	persistInterval := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
+	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second // arbitrary interval that's hopefully a sweet spot
 
 	var plan *plans.Plan
 	// If we weren't given a plan, then we refresh/plan


### PR DESCRIPTION
The `TF_BACKEND_PERSIST_INTERVAL_SECONDS` environment variable could be used to change persist interval from default 20 seconds.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.8.0
